### PR TITLE
added hacklog.mu openSUSE category

### DIFF
--- a/planetsuse/feeds
+++ b/planetsuse/feeds
@@ -2073,3 +2073,8 @@ feed 30m https://ushamim.wordpress.com/feed/
     define_nick Stallmanu
     define_lang en
     define_irc Stallmanu
+
+feed 15m https://hacklog.mu/c/opensuse/feed/
+    define_name Ish Sookun
+    define_face ishwon
+    define_lang en


### PR DESCRIPTION
Hi,

I am adding the openSUSE category of my blog hacklog.mu to planet.opensuse.org.

Regards,

Ish