### PR TITLE
Remove linux301.wordpress.com

### DIFF
--- a/planetsuse/feeds
+++ b/planetsuse/feeds
@@ -987,9 +987,6 @@ feed 15m http://lizards.opensuse.org/author/sts301/feed/
     define_face sts301
     define_irc  STS301
 
-feed 15m http://linux301.wordpress.com/feed/
-    define_name Sebastian Schöbinger
-
 feed 15m http://lizards.opensuse.org/author/jsrain/feed/
     define_name Jiri Srain
 


### PR DESCRIPTION
The feed (previously by Sebastian Schöbinger) was broken for at least
two months, and now a spammer took it over :-(