### PR TITLE
Add Dhenandi Blog and openSUSE.id

### DIFF
--- a/planetsuse/feeds
+++ b/planetsuse/feeds
@@ -2140,3 +2140,11 @@ feed 15m http://www.codeblueprint.co.uk/feed.xml
     define_name Matt Fleming
     define_irc mfleming
     define_lang en
+
+feed 15m https://opensuse.id/feed/
+    define_name Komunitas openSUSE Indonesia
+    define_lang id
+
+feed 15m https://dhenandi.com/opensuse/feed
+    define_name Muhammad Dhenandi Putra
+    define_lang id

--- a/planetsuse/feeds
+++ b/planetsuse/feeds
@@ -2145,6 +2145,10 @@ feed 15m https://opensuse.id/feed/
     define_name Komunitas openSUSE Indonesia
     define_lang id
 
-feed 15m https://dhenandi.com/opensuse/feed
+feed 15m https://dhenandi.com/tag/opensuse-eng/feed/ 
     define_name Muhammad Dhenandi Putra
-    define_lang id
+    define_lang en
+
+feed 15m https://dhenandi.com/tag/opensuse-id/feed/ 
+    define_name Muhammad Dhenandi Putra
+    define_lang en

--- a/planetsuse/feeds
+++ b/planetsuse/feeds
@@ -2151,4 +2151,4 @@ feed 15m https://dhenandi.com/tag/opensuse-eng/feed/
 
 feed 15m https://dhenandi.com/tag/opensuse-id/feed/ 
     define_name Muhammad Dhenandi Putra
-    define_lang en
+    define_lang id


### PR DESCRIPTION
Dear Admin,

I'm from openSUSE Indonesia Community, i have added my blog (dhenandi.com) which is posting about openSUSE and openSUSE Indonesia Community blog (openSUSE.id) to planet.opensuse.org. 